### PR TITLE
Fix event modal default end time

### DIFF
--- a/src/routes/(protected)/ojp/ojp-event-modal.tsx
+++ b/src/routes/(protected)/ojp/ojp-event-modal.tsx
@@ -74,14 +74,20 @@ export const OjpEventModal = component$<OjpEventModalProps>(
           setValue(formStore, "poznamka", event.poznamka || "");
         } else if (modalState.mode === "new") {
           // Nová událost
+          const startDt = initialDateTime
+            ? new Date(initialDateTime)
+            : (() => {
+                const d = new Date();
+                d.setHours(8, 0, 0, 0);
+                return d;
+              })();
+          const endDt = new Date(startDt);
+          endDt.setHours(startDt.getHours() + 1);
+
           setValue(formStore, "sal", initialSal || "BEZOVY");
-          setValue(
-            formStore,
-            "datum",
-            initialDateTime?.toISOString().split("T")[0] || new Date().toISOString().split("T")[0],
-          );
-          setValue(formStore, "casOd", initialDateTime?.toTimeString().slice(0, 5) || "08:00");
-          setValue(formStore, "casDo", "09:00");
+          setValue(formStore, "datum", startDt.toISOString().split("T")[0]);
+          setValue(formStore, "casOd", startDt.toTimeString().slice(0, 5));
+          setValue(formStore, "casDo", endDt.toTimeString().slice(0, 5));
           setValue(formStore, "title", "");
           setValue(formStore, "typ", "operace");
           setValue(formStore, "operator", "");


### PR DESCRIPTION
## Summary
- compute "Čas do" dynamically when adding a new OJP event

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration file)*
- `npm run fmt.check` *(fails: Cannot find package 'prettier-plugin-tailwindcss')*

------
https://chatgpt.com/codex/tasks/task_e_6863a422cf248333a2163779fc7625a5