### PR TITLE
Refactor OJP event modal to use useForm

### DIFF
--- a/src/routes/(protected)/ojp/ojp-event-modal.tsx
+++ b/src/routes/(protected)/ojp/ojp-event-modal.tsx
@@ -1,7 +1,20 @@
 import type { Signal } from "@builder.io/qwik";
 
-import { Button, Dialog, DialogBody, DialogFooter, DialogHeader, InputCheckbox } from "@akeso/ui-components";
+import {
+  Button,
+  Dialog,
+  DialogBody,
+  DialogFooter,
+  DialogHeader,
+  FieldDate,
+  FieldRadioSelect,
+  FieldText,
+  FieldTime,
+  InputCheckbox,
+} from "@akeso/ui-components";
 import { $, component$, useSignal, useStore, useTask$ } from "@builder.io/qwik";
+import { reset, setValue, submit, useForm, valiForm$ } from "@modular-forms/qwik";
+import * as v from "valibot";
 
 import { ButtonWithConfirmation } from "~/components/button-with-confirmation";
 
@@ -10,6 +23,18 @@ import type { OjpEvent, OjpSal } from "./_mock-events";
 import { addOjpEvent, deleteOjpEvent, updateOjpEvent } from "./_actions";
 import { _mock_ojp_events, OJP_SALY } from "./_mock-events";
 import { searchProcedures } from "./ojp-procedure-data";
+
+const OjpEventFormSchema = v.object({
+  casDo: v.pipe(v.string(), v.regex(/^\d{2}:\d{2}$/)),
+  casOd: v.pipe(v.string(), v.regex(/^\d{2}:\d{2}$/)),
+  datum: v.pipe(v.string(), v.isoDate()),
+  operator: v.optional(v.string()),
+  poznamka: v.optional(v.string()),
+  sal: v.pipe(v.string(), v.nonEmpty()),
+  title: v.pipe(v.string(), v.nonEmpty()),
+  typ: v.pipe(v.string(), v.nonEmpty()),
+});
+type FormInput = v.InferInput<typeof OjpEventFormSchema>;
 
 type OjpEventModalProps = {
   "bind:show": Signal<boolean>;
@@ -30,16 +55,20 @@ export const OjpEventModal = component$<OjpEventModalProps>(
     const isDeleting = useSignal(false);
     const errorMessage = useSignal("");
 
-    // Formulář data
-    const formData = useStore({
-      casDo: "",
-      casOd: "",
-      datum: "",
-      operator: "",
-      poznamka: "",
-      sal: "",
-      title: "",
-      typ: "",
+    const [formStore, { Form }] = useForm<FormInput>({
+      loader: {
+        value: {
+          casDo: "",
+          casOd: "",
+          datum: "",
+          operator: "",
+          poznamka: "",
+          sal: "",
+          title: "",
+          typ: "",
+        },
+      },
+      validate: valiForm$(OjpEventFormSchema),
     });
 
     // Zobrazovací data (jen pro UI, neukládají se)
@@ -85,17 +114,7 @@ export const OjpEventModal = component$<OjpEventModalProps>(
         isDeleting.value = false;
         errorMessage.value = "";
 
-        // Reset formuláře
-        Object.assign(formData, {
-          casDo: "",
-          casOd: "",
-          datum: "",
-          operator: "",
-          poznamka: "",
-          sal: "",
-          title: "",
-          typ: "",
-        });
+        reset(formStore);
 
         // Reset zobrazovacích dat
         Object.assign(displayData, {
@@ -166,23 +185,26 @@ export const OjpEventModal = component$<OjpEventModalProps>(
       const data = track(() => initialData);
 
       if (isOpen && currentMode === "new" && data) {
-        if (data.dateTime) {
-          const dateStr = data.dateTime.toISOString().split("T")[0];
-          const timeStr = data.dateTime.toTimeString().slice(0, 5);
+        const dateStr = data.dateTime
+          ? data.dateTime.toISOString().split("T")[0]
+          : "";
+        const timeStr = data.dateTime
+          ? data.dateTime.toTimeString().slice(0, 5)
+          : "";
 
-          formData.datum = dateStr;
-          formData.casOd = timeStr;
-          formData.casDo = timeStr;
-        }
+        reset(formStore, {
+          initialValues: {
+            casDo: timeStr,
+            casOd: timeStr,
+            datum: dateStr,
+            operator: "",
+            poznamka: "",
+            sal: data.sal ?? "",
+            title: "",
+            typ: "",
+          },
+        });
 
-        if (data.sal) {
-          formData.sal = data.sal;
-        }
-
-        formData.title = "";
-        formData.typ = "";
-        formData.operator = "";
-        formData.poznamka = "";
         displayData.doctorName = "";
         displayData.department = "";
         searchTerm.value = "";
@@ -199,14 +221,18 @@ export const OjpEventModal = component$<OjpEventModalProps>(
       const currentMode = track(() => modalState.mode);
 
       if ((currentMode === "edit" || currentMode === "view") && currentEvent) {
-        formData.sal = currentEvent.sal;
-        formData.datum = currentEvent.dateFrom.toISOString().split("T")[0];
-        formData.casOd = currentEvent.dateFrom.toTimeString().slice(0, 5);
-        formData.casDo = currentEvent.dateTo.toTimeString().slice(0, 5);
-        formData.title = currentEvent.title;
-        formData.typ = currentEvent.typ;
-        formData.operator = currentEvent.operator || "";
-        formData.poznamka = currentEvent.poznamka || "";
+        reset(formStore, {
+          initialValues: {
+            casDo: currentEvent.dateTo.toTimeString().slice(0, 5),
+            casOd: currentEvent.dateFrom.toTimeString().slice(0, 5),
+            datum: currentEvent.dateFrom.toISOString().split("T")[0],
+            operator: currentEvent.operator || "",
+            poznamka: currentEvent.poznamka || "",
+            sal: currentEvent.sal,
+            title: currentEvent.title,
+            typ: currentEvent.typ,
+          },
+        });
 
         // Pro zobrazení v search fieldu - zkusíme operační výkon nebo operátora
         if (currentEvent.operator) {
@@ -232,34 +258,30 @@ export const OjpEventModal = component$<OjpEventModalProps>(
       searchTerm.value = doctorName || procedure.surgery;
       showProcedures.value = false;
 
-      // Auto-vyplnění
-      formData.title = procedure.secondIdSurgeonSurgery;
+      setValue(formStore, "title", procedure.secondIdSurgeonSurgery);
 
-      // OPRAVENÉ mapování typu:
       if (procedure.type === "Úklid") {
-        formData.typ = "uklid";
+        setValue(formStore, "typ", "uklid");
       } else if (procedure.type === "Pauza") {
-        formData.typ = "pauza";
+        setValue(formStore, "typ", "pauza");
       } else if (procedure.type === "Svátek") {
-        formData.typ = "svatek";
+        setValue(formStore, "typ", "svatek");
       } else {
-        formData.typ = "operace";
+        setValue(formStore, "typ", "operace");
       }
 
-      formData.operator = procedure.surgery;
+      setValue(formStore, "operator", procedure.surgery);
 
-      // Zobrazovací data
       displayData.doctorName = doctorName;
       displayData.department = procedure.type;
 
-      // Přepočet času do
-      if (formData.casOd) {
-        const [hours, minutes] = formData.casOd.split(":").map(Number);
+      const casOd = formStore.internal.fields.casOd?.value;
+      if (casOd) {
+        const [hours, minutes] = casOd.split(":").map(Number);
         const startTime = new Date();
         startTime.setHours(hours, minutes, 0, 0);
-
         const endTime = new Date(startTime.getTime() + procedure.duration * 60 * 1000);
-        formData.casDo = endTime.toTimeString().slice(0, 5);
+        setValue(formStore, "casDo", endTime.toTimeString().slice(0, 5));
       }
     });
 
@@ -270,70 +292,7 @@ export const OjpEventModal = component$<OjpEventModalProps>(
 
     const handleSave = $(() => {
       if (isLoading.value || isDeleting.value) return;
-
-      try {
-        isLoading.value = true;
-        errorMessage.value = "";
-
-        // Pokud je formData prázdný, vezmi hodnotu z event
-        const values = {
-          casDo: formData.casDo || (event?.dateTo ? event.dateTo.toTimeString().slice(0, 5) : ""),
-          casOd: formData.casOd || (event?.dateFrom ? event.dateFrom.toTimeString().slice(0, 5) : ""),
-          datum: formData.datum || (event?.dateFrom ? event.dateFrom.toISOString().split("T")[0] : ""),
-          operator: formData.operator || event?.operator || "",
-          poznamka: formData.poznamka || event?.poznamka || "",
-          sal: formData.sal || event?.sal || "",
-          title: formData.title || event?.title || "",
-          typ: formData.typ || event?.typ || "operace",
-        };
-
-        // 🆕 VALIDACE: Kontrola úklidu po operaci
-        if (modalState.mode === "new" && values.typ === "operace") {
-          const currentDate = new Date(values.datum);
-          const existingEvents = _mock_ojp_events.filter(
-            (evt) => evt.dateFrom.toDateString() === currentDate.toDateString() && evt.sal === values.sal,
-          );
-
-          // Najdi všechny operace v řádku
-          const operations = existingEvents
-            .filter((evt) => evt.typ === "operace")
-            .sort((a, b) => b.dateTo.getTime() - a.dateTo.getTime());
-
-          // 🔧 Změna: explicitní kontrola délky pole
-          if (operations.length > 0) {
-            const lastOperation = operations[0];
-
-            // Zkontroluj, jestli po poslední operaci následuje úklid/pauza
-            const cleaningAfterLastOp = existingEvents.find(
-              (evt) => (evt.typ === "uklid" || evt.typ === "pauza") && evt.dateFrom >= lastOperation.dateTo,
-            );
-
-            if (!cleaningAfterLastOp) {
-              errorMessage.value = "Po operaci musí následovat úklid nebo pauza. Použijte 'Zobrazit ostatní sloty'.";
-              return;
-            }
-          }
-        }
-
-        let result;
-        if (modalState.mode === "new") {
-          result = addOjpEvent(values);
-        } else if (event) {
-          result = updateOjpEvent({ ...values, id: event.id });
-        }
-
-        if (result?.success) {
-          refreshTrigger.value = Date.now();
-          closeModal();
-        } else {
-          errorMessage.value = result?.message || "Nastala chyba při ukládání";
-        }
-      } catch (error) {
-        console.error("Save error:", error);
-        errorMessage.value = "Nastala chyba při ukládání";
-      } finally {
-        isLoading.value = false;
-      }
+      submit(formStore);
     });
 
     const handleDelete = $(() => {
@@ -366,6 +325,54 @@ export const OjpEventModal = component$<OjpEventModalProps>(
       }
     });
 
+    const handleSubmit = $((values: FormInput) => {
+      if (isLoading.value || isDeleting.value) return;
+      try {
+        isLoading.value = true;
+        errorMessage.value = "";
+
+        if (modalState.mode === "new" && values.typ === "operace") {
+          const currentDate = new Date(values.datum);
+          const existingEvents = _mock_ojp_events.filter(
+            (evt) => evt.dateFrom.toDateString() === currentDate.toDateString() && evt.sal === values.sal,
+          );
+          const operations = existingEvents
+            .filter((evt) => evt.typ === "operace")
+            .sort((a, b) => b.dateTo.getTime() - a.dateTo.getTime());
+          if (operations.length > 0) {
+            const lastOperation = operations[0];
+            const cleaningAfterLastOp = existingEvents.find(
+              (evt) => (evt.typ === "uklid" || evt.typ === "pauza") && evt.dateFrom >= lastOperation.dateTo,
+            );
+            if (!cleaningAfterLastOp) {
+              errorMessage.value =
+                "Po operaci musí následovat úklid nebo pauza. Použijte 'Zobrazit ostatní sloty'.";
+              return;
+            }
+          }
+        }
+
+        let result;
+        if (modalState.mode === "new") {
+          result = addOjpEvent(values);
+        } else if (event) {
+          result = updateOjpEvent({ ...values, id: event.id });
+        }
+
+        if (result?.success) {
+          refreshTrigger.value = Date.now();
+          closeModal();
+        } else {
+          errorMessage.value = result?.message || "Nastala chyba při ukládání";
+        }
+      } catch (error) {
+        console.error("Save error:", error);
+        errorMessage.value = "Nastala chyba při ukládání";
+      } finally {
+        isLoading.value = false;
+      }
+    });
+
     const isReadonly = modalState.mode === "view";
     const isNewEvent = modalState.mode === "new";
 
@@ -386,235 +393,174 @@ export const OjpEventModal = component$<OjpEventModalProps>(
       <Dialog bind:show={showSig}>
         <DialogHeader>{getModalTitle()}</DialogHeader>
 
-        <DialogBody class="form-styles">
-          <div class="grid grid-cols-1 gap-4 md:grid-cols-2">
-            <div>
-              <label class="block text-sm font-medium text-gray-700">Sál *</label>
-              <select
-                class="mt-1 block w-full rounded-md border-gray-300 shadow-sm disabled:bg-gray-100"
+        <DialogBody stoppropagation:click>
+          <Form class="form-styles" onSubmit$={handleSubmit}>
+            <div class="grid grid-cols-1 gap-4 md:grid-cols-2">
+              <FieldRadioSelect
                 disabled={isReadonly}
-                onInput$={(_, element) => {
-                  formData.sal = (element as HTMLSelectElement).value;
-                }}
-                required
-                value={event?.sal || formData.sal || ""}
-              >
-                <option value="">-- Vyberte sál --</option>
-                {OJP_SALY.map((sal) => (
-                  <option key={sal.name} value={sal.name}>
-                    {sal.displayName}
-                  </option>
-                ))}
-              </select>
-            </div>
-
-            <div>
-              <label class="block text-sm font-medium text-gray-700">Datum *</label>
-              <input
-                class="mt-1 block w-full rounded-md border-gray-300 shadow-sm disabled:bg-gray-100"
-                disabled={isReadonly}
-                onInput$={(_, element) => {
-                  formData.datum = (element as HTMLInputElement).value;
-                }}
-                required
-                type="date"
-                value={event?.dateFrom ? event.dateFrom.toISOString().split("T")[0] : formData.datum || ""}
+                label="Sál"
+                name="sal"
+                of={formStore}
+                options={OJP_SALY.map((s) => ({ label: s.displayName, value: s.name }))}
               />
-            </div>
+              <FieldDate disabled={isReadonly} label="Datum" name="datum" of={formStore} />
 
-            <div class="md:col-span-2">
-              <InputCheckbox
-                class="!mt-0"
-                disabled={isReadonly}
-                error=""
-                label="Zobrazit ostatní sloty"
-                name="showOther"
-                onInput$={(_, target) => {
-                  showOtherProcedures.value = target.checked;
-                  searchTerm.value = "";
-                }}
-                required={false}
-                switch
-                value={showOtherProcedures.value}
-              />
-            </div>
+              <div class="md:col-span-2">
+                <InputCheckbox
+                  class="!mt-0"
+                  disabled={isReadonly}
+                  label="Zobrazit ostatní sloty"
+                  name="showOther"
+                  onInput$={(_, target) => {
+                    showOtherProcedures.value = target.checked;
+                    searchTerm.value = "";
+                  }}
+                  required={false}
+                  switch
+                  value={showOtherProcedures.value}
+                />
+              </div>
 
-            <div class="md:col-span-2">
-              {showOtherProcedures.value ? (
-                // 🆕 SELECT pro ostatní sloty
-                <div>
-                  <label class="block text-sm font-medium text-gray-700">Vyberte slot</label>
-                  <select
-                    class="mt-1 block w-full rounded-md border-gray-300 shadow-sm disabled:bg-gray-100"
-                    disabled={isReadonly}
-                    onInput$={(_, element) => {
-                      const selectedId = (element as HTMLSelectElement).value;
-                      if (selectedId) {
-                        // Najdi proceduru podle ID ze "other" procedur
-                        const otherProcedures = searchProcedures("", "other");
-                        const procedure = otherProcedures.find((p) => p.id === selectedId);
-                        if (procedure) {
-                          selectProcedure(procedure);
+              <div class="md:col-span-2">
+                {showOtherProcedures.value ? (
+                  <div>
+                    <label class="block text-sm font-medium text-gray-700">Vyberte slot</label>
+                    <select
+                      class="mt-1 block w-full rounded-md border-gray-300 shadow-sm disabled:bg-gray-100"
+                      disabled={isReadonly}
+                      onInput$={(_, element) => {
+                        const selectedId = (element as HTMLSelectElement).value;
+                        if (selectedId) {
+                          const otherProcedures = searchProcedures('', 'other');
+                          const procedure = otherProcedures.find((p) => p.id === selectedId);
+                          if (procedure) {
+                            selectProcedure(procedure);
+                          }
                         }
-                      }
-                    }}
-                    value={selectedProcedure.value?.id || ""}
-                  >
-                    <option value="">-- Vyberte slot --</option>
-                    {searchProcedures("", "other").map((procedure) => (
-                      <option key={procedure.id} value={procedure.id}>
-                        {`${procedure.secondIdSurgeonSurgery} (${procedure.duration.toString()} min)`}
-                      </option>
-                    ))}
-                  </select>
-                </div>
-              ) : (
-                // 🔄 PŮVODNÍ search input pro operace
-                <div class="relative">
-                  <input
-                    class="mt-1 block w-full rounded-md border-gray-300 shadow-sm disabled:bg-gray-100"
-                    disabled={isReadonly}
-                    onInput$={(_, element) => {
-                      searchTerm.value = (element as HTMLInputElement).value;
-                    }}
-                    placeholder="Zadejte jméno lékaře nebo operační výkon..."
-                    type="text"
-                    value={searchTerm.value || ""}
-                  />
+                      }}
+                      value={selectedProcedure.value?.id || ''}
+                    >
+                      <option value="">-- Vyberte slot --</option>
+                      {searchProcedures('', 'other').map((procedure) => (
+                        <option key={procedure.id} value={procedure.id}>
+                          {`${procedure.secondIdSurgeonSurgery} (${procedure.duration.toString()} min)`}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+                ) : (
+                  <div class="relative">
+                    <input
+                      class="mt-1 block w-full rounded-md border-gray-300 shadow-sm disabled:bg-gray-100"
+                      disabled={isReadonly}
+                      onInput$={(_, element) => {
+                        searchTerm.value = (element as HTMLInputElement).value;
+                      }}
+                      placeholder="Zadejte jméno lékaře nebo operační výkon..."
+                      type="text"
+                      value={searchTerm.value || ''}
+                    />
 
-                  {showProcedures.value && !isReadonly && (
-                    <div class="absolute z-10 mt-1 w-full rounded-md border border-gray-300 bg-white shadow-lg">
-                      <div class="max-h-60 overflow-auto">
-                        {filteredProcedures.value.map((procedure) => (
-                          <button
-                            class="block w-full px-4 py-2 text-left text-sm hover:bg-gray-100"
-                            key={procedure.id}
-                            onClick$={() => selectProcedure(procedure)}
-                            type="button"
-                          >
-                            <div class="font-medium">
-                              {procedure.surgeon.firstName} {procedure.surgeon.lastName}
-                            </div>
-                            <div class="text-gray-600">{procedure.surgery}</div>
-                            <div class="text-xs text-gray-500">
-                              {procedure.duration} min | {procedure.secondIdSurgeonSurgery} | {procedure.type}
-                            </div>
-                          </button>
-                        ))}
+                    {showProcedures.value && !isReadonly && (
+                      <div class="absolute z-10 mt-1 w-full rounded-md border border-gray-300 bg-white shadow-lg">
+                        <div class="max-h-60 overflow-auto">
+                          {filteredProcedures.value.map((procedure) => (
+                            <button
+                              class="block w-full px-4 py-2 text-left text-sm hover:bg-gray-100"
+                              key={procedure.id}
+                              onClick$={() => selectProcedure(procedure)}
+                              type="button"
+                            >
+                              <div class="font-medium">
+                                {procedure.surgeon.firstName} {procedure.surgeon.lastName}
+                              </div>
+                              <div class="text-gray-600">{procedure.surgery}</div>
+                              <div class="text-xs text-gray-500">
+                                {procedure.duration} min | {procedure.secondIdSurgeonSurgery} | {procedure.type}
+                              </div>
+                            </button>
+                          ))}
+                        </div>
                       </div>
-                    </div>
-                  )}
+                    )}
+                  </div>
+                )}
+              </div>
+
+              {!showOtherProcedures.value && displayData.doctorName && (
+                <div>
+                  <label class="block text-sm font-medium text-gray-700">Lékař</label>
+                  <input
+                    class="mt-1 block w-full rounded-md border-gray-300 bg-gray-50 shadow-sm"
+                    disabled
+                    type="text"
+                    value={displayData.doctorName}
+                  />
                 </div>
               )}
-            </div>
 
-            {!showOtherProcedures.value && displayData.doctorName && (
-              <div>
-                <label class="block text-sm font-medium text-gray-700">Lékař</label>
-                <input
-                  class="mt-1 block w-full rounded-md border-gray-300 bg-gray-50 shadow-sm"
-                  disabled
-                  type="text"
-                  value={displayData.doctorName}
-                />
-              </div>
-            )}
+              {!showOtherProcedures.value && displayData.department && (
+                <div>
+                  <label class="block text-sm font-medium text-gray-700">Oddělení</label>
+                  <input
+                    class="mt-1 block w-full rounded-md border-gray-300 bg-gray-50 shadow-sm"
+                    disabled
+                    type="text"
+                    value={displayData.department}
+                  />
+                </div>
+              )}
 
-            {!showOtherProcedures.value && displayData.department && (
-              <div>
-                <label class="block text-sm font-medium text-gray-700">Oddělení</label>
-                <input
-                  class="mt-1 block w-full rounded-md border-gray-300 bg-gray-50 shadow-sm"
-                  disabled
-                  type="text"
-                  value={displayData.department}
-                />
-              </div>
-            )}
-
-            <div>
-              <label class="block text-sm font-medium text-gray-700">Čas od *</label>
-              <input
-                class="mt-1 block w-full rounded-md border-gray-300 shadow-sm disabled:bg-gray-100"
+              <FieldTime
                 disabled={isReadonly}
+                label="Čas od"
+                name="casOd"
+                of={formStore}
                 onInput$={(_, element) => {
-                  formData.casOd = (element as HTMLInputElement).value;
-
-                  // Přepočet času do pokud je vybraná procedura
-                  if (selectedProcedure.value && formData.casOd) {
-                    const [hours, minutes] = formData.casOd.split(":").map(Number);
-                    const startTime = new Date();
-                    startTime.setHours(hours, minutes, 0, 0);
-
-                    const endTime = new Date(startTime.getTime() + selectedProcedure.value.duration * 60 * 1000);
-                    formData.casDo = endTime.toTimeString().slice(0, 5);
+                  const val = (element as HTMLInputElement).value;
+                  const proc = selectedProcedure.value;
+                  if (proc && val) {
+                    const [h, m] = val.split(':').map(Number);
+                    const start = new Date();
+                    start.setHours(h, m, 0, 0);
+                    const end = new Date(start.getTime() + proc.duration * 60 * 1000);
+                    setValue(formStore, 'casDo', end.toTimeString().slice(0, 5));
                   }
                 }}
-                required
-                type="time"
-                value={event?.dateFrom ? event.dateFrom.toTimeString().slice(0, 5) : formData.casOd || ""}
               />
+
+              <FieldTime disabled={isReadonly} label="Čas do" name="casDo" of={formStore} />
+
+              <FieldText disabled={isReadonly} inputType="text" label="Název události" name="title" of={formStore} />
             </div>
 
-            <div>
-              <label class="block text-sm font-medium text-gray-700">Čas do *</label>
-              <input
-                class="mt-1 block w-full rounded-md border-gray-300 shadow-sm disabled:bg-gray-100"
-                disabled={isReadonly}
-                onInput$={(_, element) => {
-                  formData.casDo = (element as HTMLInputElement).value;
-                }}
-                required
-                type="time"
-                value={event?.dateTo ? event.dateTo.toTimeString().slice(0, 5) : formData.casDo || ""}
-              />
-            </div>
-
-            <div>
-              <label class="block text-sm font-medium text-gray-700">Název události *</label>
-              <input
-                class="mt-1 block w-full rounded-md border-gray-300 shadow-sm disabled:bg-gray-100"
-                disabled={isReadonly}
-                onInput$={(_, element) => {
-                  formData.title = (element as HTMLInputElement).value;
-                }}
-                required
-                type="text"
-                value={event?.title || formData.title || ""}
-              />
-            </div>
-          </div>
-
-          <div class="mt-4">
-            {!showOtherProcedures.value && (
-              <div>
-                <label class="block text-sm font-medium text-gray-700">Operační výkon</label>
-                <input
-                  class="mt-1 block w-full rounded-md border-gray-300 shadow-sm disabled:bg-gray-100"
+            <div class="mt-4">
+              {!showOtherProcedures.value && (
+                <FieldText
                   disabled={isReadonly}
-                  onInput$={(_, element) => {
-                    formData.operator = (element as HTMLInputElement).value;
-                  }}
-                  type="text"
-                  value={event?.operator || formData.operator || ""}
+                  inputType="text"
+                  label="Operační výkon"
+                  name="operator"
+                  of={formStore}
+                  required={false}
                 />
+              )}
+              <FieldText
+                disabled={isReadonly}
+                inputType="textarea"
+                label="Poznámka"
+                name="poznamka"
+                of={formStore}
+                required={false}
+              />
+            </div>
+
+            {errorMessage.value && (
+              <div class="mt-4 rounded border border-red-400 bg-red-100 p-3 text-red-700">
+                {errorMessage.value}
               </div>
             )}
-            <label class="block text-sm font-medium text-gray-700">Poznámka</label>
-            <textarea
-              class="mt-1 block w-full rounded-md border-gray-300 shadow-sm disabled:bg-gray-100"
-              disabled={isReadonly}
-              onInput$={(_, element) => {
-                formData.poznamka = (element as HTMLTextAreaElement).value;
-              }}
-              rows={3}
-              value={event?.poznamka || formData.poznamka || ""}
-            />
-          </div>
-
-          {errorMessage.value && (
-            <div class="mt-4 rounded border border-red-400 bg-red-100 p-3 text-red-700">{errorMessage.value}</div>
-          )}
+          </Form>
         </DialogBody>
 
         <DialogFooter class="flex items-center justify-between">


### PR DESCRIPTION
## Summary
- switch manual form store to `useForm`
- add `OjpEventFormSchema` validation with valibot
- reset form using `reset()` on open
- use Akeso form fields in the modal
- submit via `submit(formStore)`

## Testing
- `bun run lint` *(fails: ESLint couldn't find config)*
- `bun run fmt` *(fails: Cannot find package 'prettier-plugin-tailwindcss')*

------
https://chatgpt.com/codex/tasks/task_e_6874bf82dc248333b7c555b8de44c2f8